### PR TITLE
Attributes: Handle explicit default of null/blank and introduce mandatory attributes

### DIFF
--- a/src/main/java/org/frankframework/frankdoc/AttributeTypeStrategy.java
+++ b/src/main/java/org/frankframework/frankdoc/AttributeTypeStrategy.java
@@ -66,8 +66,8 @@ public enum AttributeTypeStrategy {
 		this.delegate = delegate;
 	}
 
-	XmlBuilder addAttribute(XmlBuilder context, String name, AttributeType modelAttributeType) {
-		return delegate.addAttribute(context, name, modelAttributeType);
+	XmlBuilder addAttribute(XmlBuilder context, String name, AttributeType modelAttributeType, boolean isMandatory) {
+		return delegate.addAttribute(context, name, modelAttributeType, isMandatory);
 	}
 
 	XmlBuilder addRestrictedAttribute(XmlBuilder context, FrankAttribute attribute) {
@@ -91,11 +91,12 @@ public enum AttributeTypeStrategy {
 		// For example, an integer attribute can still be set like "${someIdentifier}".
 		// This method expects that methods DocWriterNewXmlUtils.createTypeFrankBoolean() and
 		// DocWriterNewXmlUtils.createTypeFrankInteger() are used to define the referenced XSD types.
-		XmlBuilder addAttribute(XmlBuilder context, String name, AttributeType modelAttributeType) {
-			return addAttribute(context, name, modelAttributeType, FRANK_BOOLEAN, FRANK_INT);
+		XmlBuilder addAttribute(XmlBuilder context, String name, AttributeType modelAttributeType, boolean isMandatory) {
+			return addAttribute(context, name, modelAttributeType, isMandatory, FRANK_BOOLEAN, FRANK_INT);
 		}
 
-		private final XmlBuilder addAttribute(XmlBuilder context, String name, AttributeType modelAttributeType, String boolType, String intType) {
+		private final XmlBuilder addAttribute(XmlBuilder context, String name, AttributeType modelAttributeType, boolean isMandatory,
+				String boolType, String intType) {
 			XmlBuilder attribute = new XmlBuilder("attribute", "xs", XML_SCHEMA_URI);
 			attribute.addAttribute("name", name);
 			String typeName = null;
@@ -111,6 +112,9 @@ public enum AttributeTypeStrategy {
 				break;
 			}
 			attribute.addAttribute("type", typeName);
+			if(isMandatory) {
+				attribute.addAttribute("use", "required");
+			}
 			context.addSubElement(attribute);
 			return attribute;						
 		}

--- a/src/main/java/org/frankframework/frankdoc/DocWriterNew.java
+++ b/src/main/java/org/frankframework/frankdoc/DocWriterNew.java
@@ -409,7 +409,10 @@ public class DocWriterNew {
 		xsdElements.add(startElementBuilder);
 		addDocumentation(startElementBuilder, Constants.MODULE_ELEMENT_DESCRIPTION);
 		XmlBuilder complexType = addComplexType(startElementBuilder);
-		DocWriterNewXmlUtils.addGroupRef(complexType, getConfigChildGroupOf(startElement));
+		String declaredChildGroup = getConfigChildGroupOf(startElement);
+		if(declaredChildGroup != null) {
+			DocWriterNewXmlUtils.addGroupRef(complexType, declaredChildGroup);
+		}
 		attributeTypeStrategy.addAttributeActive(complexType);		
 	}
 
@@ -418,6 +421,10 @@ public class DocWriterNew {
 		// ancestors with config children. Or even take a declared/cumulative group of an ancestor
 		// if <Configuration> itself has no config children. These do not apply in practice, so
 		// implementing this has not a high priority.
+		if(frankElement.getCumulativeConfigChildren(version.getChildSelector(), version.getChildRejector()).isEmpty()) {
+			// This will not happen in production, but we have integration tests in which config children are not relevant.
+			return null;
+		}
 		if(frankElement.hasOrInheritsPluralConfigChildren(version.getChildSelector(), version.getChildRejector())) {
 			return xsdPluralGroupNameForChildren(frankElement);
 		} else {

--- a/src/main/java/org/frankframework/frankdoc/DocWriterNew.java
+++ b/src/main/java/org/frankframework/frankdoc/DocWriterNew.java
@@ -1129,7 +1129,8 @@ public class DocWriterNew {
 				// The default value in the model is a *description* of the default value.
 				// Therefore, it should be added to the description in the xs:attribute.
 				// The "default" attribute of the xs:attribute should not be set.
-				attribute = attributeTypeStrategy.addAttribute(context, frankAttribute.getName(), frankAttribute.getAttributeType());
+				attribute = attributeTypeStrategy.addAttribute(
+						context, frankAttribute.getName(), frankAttribute.getAttributeType(), frankAttribute.isMandatory());
 			} else {
 				attribute = addRestrictedAttribute(context, frankAttribute);
 			}

--- a/src/main/java/org/frankframework/frankdoc/model/ElementChild.java
+++ b/src/main/java/org/frankframework/frankdoc/model/ElementChild.java
@@ -117,6 +117,10 @@ public abstract class ElementChild {
 		this.owningElement = owningElement;
 	}
 
+	void clearDefaultValue() {
+		defaultValue = null;
+	}
+
 	void calculateOverriddenFrom() {
 		FrankElement match = getOwningElement();
 		while(match.getParent() != null) {

--- a/src/main/java/org/frankframework/frankdoc/model/FrankAttribute.java
+++ b/src/main/java/org/frankframework/frankdoc/model/FrankAttribute.java
@@ -90,6 +90,9 @@ public class FrankAttribute extends ElementChild {
 		if(getDefaultValue() == null) {
 			return;
 		}
+		if(mandatory) {
+			log.warn("Attribute [{}] is mandatory, but it also has a default value: [{}]", toString(), getDefaultValue());
+		}
 		boolean isExplicitNull = (StringUtils.isBlank(getDefaultValue()) || getDefaultValue().equals("null"));
 		if(isExplicitNull && parameterType.isPrimitive()) {
 			log.warn("Attribute [{}] is of primitive type [{}] but has default value null", toString(), parameterType.toString());

--- a/src/main/java/org/frankframework/frankdoc/model/FrankAttribute.java
+++ b/src/main/java/org/frankframework/frankdoc/model/FrankAttribute.java
@@ -31,6 +31,7 @@ public class FrankAttribute extends ElementChild {
 	private static Logger log = LogUtil.getLogger(FrankAttribute.class);
 
 	static final String JAVADOC_NO_FRANK_ATTRIBUTE = "@ff.noAttribute";
+	static final String JAVADOC_ATTRIBUTE_MANDATORY = "@ff.mandatory";
 
 	@EqualsAndHashCode(callSuper = false)
 	static class Key extends AbstractKey {
@@ -62,6 +63,7 @@ public class FrankAttribute extends ElementChild {
 	 * not exist, then it also should not be inherited.
 	 */
 	private @Getter @Setter(AccessLevel.PACKAGE) boolean excluded = false;
+	private @Getter @Setter(AccessLevel.PACKAGE) boolean mandatory = false;
 
 	public FrankAttribute(String name, FrankElement attributeOwner) {
 		super(attributeOwner);

--- a/src/main/java/org/frankframework/frankdoc/model/FrankDocModel.java
+++ b/src/main/java/org/frankframework/frankdoc/model/FrankDocModel.java
@@ -459,6 +459,7 @@ public class FrankDocModel {
 			log.trace("For attribute [{}], have @IbisDoc without @IbisDocRef", attribute);
 			attribute.parseIbisDocAnnotation(ibisDoc);
 		}
+		attribute.handleDefaultExplicitNull(method.getParameterTypes()[0]);
 		log.trace("Done documenting attribute [{}]", () -> attribute.getName());
 	}
 

--- a/src/main/java/org/frankframework/frankdoc/model/FrankDocModel.java
+++ b/src/main/java/org/frankframework/frankdoc/model/FrankDocModel.java
@@ -290,6 +290,9 @@ public class FrankDocModel {
 				checkForTypeConflict(method, getterAttributes.get(attributeName), attributeOwner);
 			}
 			FrankAttribute attribute = new FrankAttribute(attributeName, attributeOwner);
+			if(method.getJavaDocTag(FrankAttribute.JAVADOC_ATTRIBUTE_MANDATORY) != null) {
+				attribute.setMandatory(true);
+			}
 			if(method.getParameterTypes()[0].isEnum()) {
 				log.trace("Attribute [{}] has setter that takes enum: [{}]", () -> attribute.getName(), () -> method.getParameterTypes()[0].toString());
 				attribute.setAttributeType(AttributeType.STRING);

--- a/src/main/java/org/frankframework/frankdoc/wrapper/FrankSimpleType.java
+++ b/src/main/java/org/frankframework/frankdoc/wrapper/FrankSimpleType.java
@@ -47,4 +47,9 @@ abstract class FrankSimpleType implements FrankType {
 	public boolean isEnum() {
 		return false;
 	}
+
+	@Override
+	public String toString() {
+		return name;
+	}
 }

--- a/src/test/java/org/frankframework/frankdoc/AttributeTypeStrategyTest.java
+++ b/src/test/java/org/frankframework/frankdoc/AttributeTypeStrategyTest.java
@@ -121,9 +121,10 @@ public class AttributeTypeStrategyTest {
 		XmlBuilder schema = getXmlSchema();
 		XmlBuilder element = addElementWithType(schema, "myElement");
 		XmlBuilder complexType = addComplexType(element);
-		attributeTypeStrategy.addAttribute(complexType, "boolAttr", AttributeType.BOOL);
-		attributeTypeStrategy.addAttribute(complexType, "intAttr", AttributeType.INT);
-		attributeTypeStrategy.addAttribute(complexType, "stringAttr", AttributeType.STRING);
+		// We do not test mandatory attributes here. Therefore the fourth argument is "false".
+		attributeTypeStrategy.addAttribute(complexType, "boolAttr", AttributeType.BOOL, false);
+		attributeTypeStrategy.addAttribute(complexType, "intAttr", AttributeType.INT, false);
+		attributeTypeStrategy.addAttribute(complexType, "stringAttr", AttributeType.STRING, false);
 		attributeTypeStrategy.addAttributeActive(complexType);
 		attributeTypeStrategy.addRestrictedAttribute(complexType, enumTypedAttribute);
 		attributeTypeStrategy.createHelperTypes().forEach(h -> schema.addSubElement(h));

--- a/src/test/java/org/frankframework/frankdoc/DocWriterNewAndJsonGenerationExamplesTest.java
+++ b/src/test/java/org/frankframework/frankdoc/DocWriterNewAndJsonGenerationExamplesTest.java
@@ -70,6 +70,8 @@ public class DocWriterNewAndJsonGenerationExamplesTest {
 			// The resulting JSON file is not relevant. Please run this test separately and check that you have warnings about overloaded attributes.
 			{XsdVersion.STRICT, AttributeTypeStrategy.ALLOW_PROPERTY_REF, "general-test-digester-rules.xml", "org.frankframework.frankdoc.testtarget.attribute.overload.Master", null, "overloadedAttributes.json"},
 			{XsdVersion.STRICT, AttributeTypeStrategy.ALLOW_PROPERTY_REF, "general-test-digester-rules.xml", "org.frankframework.frankdoc.testtarget.attribute.enumExclude.Master", "enumExcludedAttributes.xsd", "enumExcludedAttributes.json"},
+			// Should produce the following warning:
+			// Attribute [Master.explicitNullOnPrimitive] is of primitive type [short] but has default value null
 			{XsdVersion.STRICT, AttributeTypeStrategy.ALLOW_PROPERTY_REF, "general-test-digester-rules.xml", "org.frankframework.frankdoc.testtarget.attributeDefault.Master", "attributeDefault.xsd", null}
 		});
 	}

--- a/src/test/java/org/frankframework/frankdoc/DocWriterNewAndJsonGenerationExamplesTest.java
+++ b/src/test/java/org/frankframework/frankdoc/DocWriterNewAndJsonGenerationExamplesTest.java
@@ -69,7 +69,8 @@ public class DocWriterNewAndJsonGenerationExamplesTest {
 			{XsdVersion.STRICT, AttributeTypeStrategy.ALLOW_PROPERTY_REF, "general-test-digester-rules.xml", "org.frankframework.frankdoc.testtarget.element.name.Master", null, "elementNames.json"},
 			// The resulting JSON file is not relevant. Please run this test separately and check that you have warnings about overloaded attributes.
 			{XsdVersion.STRICT, AttributeTypeStrategy.ALLOW_PROPERTY_REF, "general-test-digester-rules.xml", "org.frankframework.frankdoc.testtarget.attribute.overload.Master", null, "overloadedAttributes.json"},
-			{XsdVersion.STRICT, AttributeTypeStrategy.ALLOW_PROPERTY_REF, "general-test-digester-rules.xml", "org.frankframework.frankdoc.testtarget.attribute.enumExclude.Master", "enumExcludedAttributes.xsd", "enumExcludedAttributes.json"}
+			{XsdVersion.STRICT, AttributeTypeStrategy.ALLOW_PROPERTY_REF, "general-test-digester-rules.xml", "org.frankframework.frankdoc.testtarget.attribute.enumExclude.Master", "enumExcludedAttributes.xsd", "enumExcludedAttributes.json"},
+			{XsdVersion.STRICT, AttributeTypeStrategy.ALLOW_PROPERTY_REF, "general-test-digester-rules.xml", "org.frankframework.frankdoc.testtarget.attributeDefault.Master", "attributeDefault.xsd", null}
 		});
 	}
 

--- a/src/test/java/org/frankframework/frankdoc/DocWriterNewAndJsonGenerationExamplesTest.java
+++ b/src/test/java/org/frankframework/frankdoc/DocWriterNewAndJsonGenerationExamplesTest.java
@@ -70,8 +70,9 @@ public class DocWriterNewAndJsonGenerationExamplesTest {
 			// The resulting JSON file is not relevant. Please run this test separately and check that you have warnings about overloaded attributes.
 			{XsdVersion.STRICT, AttributeTypeStrategy.ALLOW_PROPERTY_REF, "general-test-digester-rules.xml", "org.frankframework.frankdoc.testtarget.attribute.overload.Master", null, "overloadedAttributes.json"},
 			{XsdVersion.STRICT, AttributeTypeStrategy.ALLOW_PROPERTY_REF, "general-test-digester-rules.xml", "org.frankframework.frankdoc.testtarget.attribute.enumExclude.Master", "enumExcludedAttributes.xsd", "enumExcludedAttributes.json"},
-			// Should produce the following warning:
+			// Should produce the following warnings (not necessarily right after each other):
 			// Attribute [Master.explicitNullOnPrimitive] is of primitive type [short] but has default value null
+			// Attribute [Master.mandatoryWithDefault] is mandatory, but it also has a default value: [something]
 			{XsdVersion.STRICT, AttributeTypeStrategy.ALLOW_PROPERTY_REF, "general-test-digester-rules.xml", "org.frankframework.frankdoc.testtarget.attributeDefault.Master", "attributeDefault.xsd", null}
 		});
 	}

--- a/src/test/java/org/frankframework/frankdoc/testtarget/attributeDefault/Master.java
+++ b/src/test/java/org/frankframework/frankdoc/testtarget/attributeDefault/Master.java
@@ -1,0 +1,31 @@
+package org.frankframework.frankdoc.testtarget.attributeDefault;
+
+import nl.nn.adapterframework.doc.IbisDoc;
+
+public class Master {
+	// No default, because "null"
+	@IbisDoc({"10", "Description setBooleanExplicitNull()", "null"})
+	public void setBooleanExplicitNull(Boolean b) {
+	}
+
+	// No default, because blank
+	/**
+	 * @ff.default
+	 */
+	public void setStringExplicitNull(String s) {
+	}
+
+	public void setIntegerNoDefault(Integer i) {
+	}
+
+	/**
+	 * @ff.default 50
+	 */
+	public void setByteWithDefault(Byte b) {
+	}
+
+	// Should produce a warning
+	@IbisDoc({"20", "Description setExplicitNullOnPrimitive()", "null"})
+	public void setExplicitNullOnPrimitive(short s) {
+	}
+}

--- a/src/test/java/org/frankframework/frankdoc/testtarget/attributeDefault/Master.java
+++ b/src/test/java/org/frankframework/frankdoc/testtarget/attributeDefault/Master.java
@@ -28,4 +28,10 @@ public class Master {
 	@IbisDoc({"20", "Description setExplicitNullOnPrimitive()", "null"})
 	public void setExplicitNullOnPrimitive(short s) {
 	}
+
+	/**
+	 * @ff.mandatory
+	 */
+	public void setMandatory(boolean b) {
+	}
 }

--- a/src/test/java/org/frankframework/frankdoc/testtarget/attributeDefault/Master.java
+++ b/src/test/java/org/frankframework/frankdoc/testtarget/attributeDefault/Master.java
@@ -34,4 +34,13 @@ public class Master {
 	 */
 	public void setMandatory(boolean b) {
 	}
+
+	// Should produce a warning
+	/**
+	 * @ff.default something
+	 * @ff.mandatory
+	 * @param s
+	 */
+	public void setMandatoryWithDefault(String s) {
+	}
 }

--- a/src/test/resources/doc/examplesExpected/attributeDefault.xsd
+++ b/src/test/resources/doc/examplesExpected/attributeDefault.xsd
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="Master">
+    <xs:annotation>
+      <xs:documentation>org.frankframework.frankdoc.testtarget.attributeDefault.Master</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="MasterType">
+          <xs:attribute ref="active" />
+          <xs:attribute name="className" type="xs:string" fixed="org.frankframework.frankdoc.testtarget.attributeDefault.Master" use="prohibited" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Module">
+    <xs:annotation>
+      <xs:documentation>Root element for file you include as entity reference. Does not influence the behavior of your Frank config.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute ref="active" />
+    </xs:complexType>
+  </xs:element>
+  <xs:complexType name="MasterType">
+    <xs:attributeGroup ref="MasterDeclaredAttributeGroup" />
+  </xs:complexType>
+  <xs:attributeGroup name="MasterDeclaredAttributeGroup">
+    <xs:attribute name="booleanExplicitNull" type="frankBoolean">
+      <xs:annotation>
+        <xs:documentation>Description setBooleanExplicitNull()</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="stringExplicitNull" type="xs:string" />
+    <xs:attribute name="integerNoDefault" type="frankInt" />
+    <xs:attribute name="byteWithDefault" type="frankInt">
+      <xs:annotation>
+        <xs:documentation>Default: 50</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="explicitNullOnPrimitive" type="frankInt">
+      <xs:annotation>
+        <xs:documentation>Description setExplicitNullOnPrimitive() Default: null</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:simpleType name="frankBoolean">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="(true|false)|($\{[^\}]+\})" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="frankInt">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="((\+|-)?[0-9]+)|($\{[^\}]+\})" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:attribute name="active">
+    <xs:annotation>
+      <xs:documentation>If defined and empty or false, then this element and all its children are ignored</xs:documentation>
+    </xs:annotation>
+    <xs:simpleType>
+      <xs:restriction base="xs:string">
+        <xs:pattern value="\!?(($\{[^\}]+\})|([tT][rR][uU][eE])|([fF][aA][lL][sS][eE]))" />
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+  <xs:simpleType name="variableRef">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="$\{[^\}]+\}" />
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/src/test/resources/doc/examplesExpected/attributeDefault.xsd
+++ b/src/test/resources/doc/examplesExpected/attributeDefault.xsd
@@ -42,6 +42,7 @@
         <xs:documentation>Description setExplicitNullOnPrimitive() Default: null</xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="mandatory" type="frankBoolean" use="required" />
   </xs:attributeGroup>
   <xs:simpleType name="frankBoolean">
     <xs:restriction base="xs:string">

--- a/src/test/resources/doc/examplesExpected/attributeDefault.xsd
+++ b/src/test/resources/doc/examplesExpected/attributeDefault.xsd
@@ -43,6 +43,11 @@
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="mandatory" type="frankBoolean" use="required" />
+    <xs:attribute name="mandatoryWithDefault" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>Default: something</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
   </xs:attributeGroup>
   <xs:simpleType name="frankBoolean">
     <xs:restriction base="xs:string">


### PR DESCRIPTION
This pull adds the following features:
* If an attribute is of non-primitive type (e.g. Boolean, String), then the following applies. You can explicitly set a default value of null. This makes explicit that it is allowed not to set the attribute. But nobody will set such an attribute to null in a Frank config. An attribute with an explicit default of null should thus have no default value in the XSDs. Both the empty string and "null" are treated as explicit null. An explicit null can be set using @ff.default or with @IbisDoc.
* A warning is written if an attribute of primitive type has an explicit null. In a future pull request I intend to change this into an error that breaks the build.
* If a primitive-typed attribute has no default value, then omitting it is still allowed by the Frank!Doc. It is up to the F!F to handle this case. Contributors should document the default using @ff.default, or the attribute should be made mandatory as explained below.
* A JavaDoc tag @ff.mandatory is introduced. When it is set on an attribute setter, the attribute gets `use="required` in both the strict and the compatibility XSD. Frank developers see an error when they omit a mandatory attribute. And the F!F will fail to load the config if a mandatory attribute is not set.
* A warning is written if a mandatory attribute has a default value as well. I intend to change this into an error that breaks the build.
