### PR TITLE
Introduce tag ff.refer to replace IbisDocRef

### DIFF
--- a/src/main/java/org/frankframework/frankdoc/model/FrankAttribute.java
+++ b/src/main/java/org/frankframework/frankdoc/model/FrankAttribute.java
@@ -32,6 +32,7 @@ public class FrankAttribute extends ElementChild {
 
 	static final String JAVADOC_NO_FRANK_ATTRIBUTE = "@ff.noAttribute";
 	static final String JAVADOC_ATTRIBUTE_MANDATORY = "@ff.mandatory";
+	static final String JAVADOC_ATTRIBUTE_REFER = "@ff.refer";
 
 	@EqualsAndHashCode(callSuper = false)
 	static class Key extends AbstractKey {

--- a/src/main/java/org/frankframework/frankdoc/model/FrankAttribute.java
+++ b/src/main/java/org/frankframework/frankdoc/model/FrankAttribute.java
@@ -32,7 +32,7 @@ public class FrankAttribute extends ElementChild {
 
 	static final String JAVADOC_NO_FRANK_ATTRIBUTE = "@ff.noAttribute";
 	static final String JAVADOC_ATTRIBUTE_MANDATORY = "@ff.mandatory";
-	static final String JAVADOC_ATTRIBUTE_REFER = "@ff.refer";
+	static final String JAVADOC_ATTRIBUTE_REF = "@ff.ref";
 
 	@EqualsAndHashCode(callSuper = false)
 	static class Key extends AbstractKey {

--- a/src/main/java/org/frankframework/frankdoc/model/FrankDocModel.java
+++ b/src/main/java/org/frankframework/frankdoc/model/FrankDocModel.java
@@ -435,16 +435,16 @@ public class FrankDocModel {
 				|| (method.getAnnotation(FrankDocletConstants.IBISDOCREF) != null)
 				|| (method.getJavaDoc() != null)
 				|| (method.getJavaDocTag(ElementChild.JAVADOC_DEFAULT_VALUE_TAG) != null)
-				|| (method.getJavaDocTag(FrankAttribute.JAVADOC_ATTRIBUTE_REFER) != null));
+				|| (method.getJavaDocTag(FrankAttribute.JAVADOC_ATTRIBUTE_REF) != null));
 		log.trace("Attribute: deprecated = [{}], documented = [{}]", () -> attribute.isDeprecated(), () -> attribute.isDocumented());
-		String ffReferReference = method.getJavaDocTag(FrankAttribute.JAVADOC_ATTRIBUTE_REFER);
-		if(ffReferReference != null) {
-			if(StringUtils.isBlank(ffReferReference)) {
-				log.error("JavaDoc tag {} should have a full class name or full method name as argument", FrankAttribute.JAVADOC_ATTRIBUTE_REFER);
+		String ffRefReference = method.getJavaDocTag(FrankAttribute.JAVADOC_ATTRIBUTE_REF);
+		if(ffRefReference != null) {
+			if(StringUtils.isBlank(ffRefReference)) {
+				log.error("JavaDoc tag {} should have a full class name or full method name as argument", FrankAttribute.JAVADOC_ATTRIBUTE_REF);
 			} else {
-				FrankMethod referred = getReferredMethod(ffReferReference, method);
+				FrankMethod referred = getReferredMethod(ffRefReference, method);
 				if(referred == null) {
-					log.error("Referred method [{}] does not exist", ffReferReference);
+					log.error("Referred method [{}] does not exist", ffRefReference);
 				} else {
 					attribute.setDescribingElement(findOrCreateFrankElement(referred.getDeclaringClass().getName()));
 					attribute.setJavaDocBasedDescriptionAndDefault(referred);

--- a/src/main/java/org/frankframework/frankdoc/model/FrankDocModel.java
+++ b/src/main/java/org/frankframework/frankdoc/model/FrankDocModel.java
@@ -434,8 +434,23 @@ public class FrankDocModel {
 				(method.getAnnotation(FrankDocletConstants.IBISDOC) != null)
 				|| (method.getAnnotation(FrankDocletConstants.IBISDOCREF) != null)
 				|| (method.getJavaDoc() != null)
-				|| (method.getJavaDocTag(ElementChild.JAVADOC_DEFAULT_VALUE_TAG) != null));
+				|| (method.getJavaDocTag(ElementChild.JAVADOC_DEFAULT_VALUE_TAG) != null)
+				|| (method.getJavaDocTag(FrankAttribute.JAVADOC_ATTRIBUTE_REFER) != null));
 		log.trace("Attribute: deprecated = [{}], documented = [{}]", () -> attribute.isDeprecated(), () -> attribute.isDocumented());
+		String ffReferReference = method.getJavaDocTag(FrankAttribute.JAVADOC_ATTRIBUTE_REFER);
+		if(ffReferReference != null) {
+			if(StringUtils.isBlank(ffReferReference)) {
+				log.error("JavaDoc tag {} should have a full class name or full method name as argument", FrankAttribute.JAVADOC_ATTRIBUTE_REFER);
+			} else {
+				FrankMethod referred = getReferredMethod(ffReferReference, method);
+				if(referred == null) {
+					log.error("Referred method [{}] does not exist", ffReferReference);
+				} else {
+					attribute.setDescribingElement(findOrCreateFrankElement(referred.getDeclaringClass().getName()));
+					attribute.setJavaDocBasedDescriptionAndDefault(referred);
+				}
+			}
+		}
 		attribute.setJavaDocBasedDescriptionAndDefault(method);
 		FrankAnnotation ibisDocRef = method.getAnnotationInludingInherited(FrankDocletConstants.IBISDOCREF);
 		if(ibisDocRef != null) {

--- a/src/test/java/org/frankframework/frankdoc/model/FrankDocModelTest.java
+++ b/src/test/java/org/frankframework/frankdoc/model/FrankDocModelTest.java
@@ -512,6 +512,17 @@ public class FrankDocModelTest {
 	}
 
 	@Test
+	public void testFfReferWithInheritedDescriptionAndDefault() throws Exception {
+		FrankAttribute actual = checkIbisdocrefInvestigatedFrankAttribute("ffReferInheritedDescription");
+		assertTrue(actual.isDocumented());
+		assertFalse(actual.isMandatory());
+		assertSame(instance.getAllElements().get(REFERRED_PARENT), actual.getDescribingElement());
+		assertSame(attributeOwner, actual.getOwningElement());
+		assertEquals("Description of setFfReferInheritedDescription", actual.getDescription());
+		assertEquals("Value of setFfReferInheritedDescription", actual.getDefaultValue());
+	}
+
+	@Test
 	public void whenMethodOverriddenWithoutDocThenDocumentedFalseButIbisDocRefInfoInherited() throws FrankDocException {
 		FrankAttribute actual = checkIbisdocrefInvestigatedFrankAttribute("ibisDocRefClassNoOrderRefersIbisDocOrderDescriptionDefault", REFERRER_CHILD);
 		assertFalse(actual.isDocumented());

--- a/src/test/java/org/frankframework/frankdoc/testtarget/ibisdocref/ParentTarget.java
+++ b/src/test/java/org/frankframework/frankdoc/testtarget/ibisdocref/ParentTarget.java
@@ -6,4 +6,12 @@ public class ParentTarget {
 	@IbisDoc({"100", "Description of ibisDocRefClassWithOrderRefersIbisDocOrderDescriptionDefaultInherited"})
 	public void setIbisDocRefClassWithOrderRefersIbisDocOrderDescriptionDefaultInherited(String value) {
 	}
+
+	/**
+	 * Description of setFfReferInheritedDescription
+	 * 
+	 * @ff.default Value of setFfReferInheritedDescription
+	 */
+	public void setFfReferInheritedDescription(String value) {
+	}
 }

--- a/src/test/java/org/frankframework/frankdoc/testtarget/ibisdocref/Referrer.java
+++ b/src/test/java/org/frankframework/frankdoc/testtarget/ibisdocref/Referrer.java
@@ -32,7 +32,7 @@ public class Referrer {
 	}
 
 	/**
-	 * @ff.refer org.frankframework.frankdoc.testtarget.ibisdocref.ChildTarget
+	 * @ff.ref org.frankframework.frankdoc.testtarget.ibisdocref.ChildTarget
 	 * 
 	 */
 	public void setFfReferInheritedDescription(String value) {

--- a/src/test/java/org/frankframework/frankdoc/testtarget/ibisdocref/Referrer.java
+++ b/src/test/java/org/frankframework/frankdoc/testtarget/ibisdocref/Referrer.java
@@ -30,4 +30,11 @@ public class Referrer {
 	@IbisDocRef("org.frankframework.frankdoc.testtarget.ibisdocref.ChildTarget")
 	public void setIbisDocRefRefersJavaDocDefault(String value) {
 	}
+
+	/**
+	 * @ff.refer org.frankframework.frankdoc.testtarget.ibisdocref.ChildTarget
+	 * 
+	 */
+	public void setFfReferInheritedDescription(String value) {
+	}
 }


### PR DESCRIPTION
This is a very basic implementation. I have the following ideas to extend it:

* If there an attribute has a description and ff.refer, then the description found via ff.refer is overwritten by JavaDoc on the method. We may combine the two instead of choosing one. In that case: do we add a separator like `<p>`?
* There are many sources (IbisDoc, IbisDocRef, JavaDoc, ff.refer) of default values and descriptions. There are no warnings if these conflict. Shall I add such warnings?
* Shall I add that ff.mandatory or ff.noAttribute on the referred method are applied for the attribute?