### PR TITLE
Refactor GitHub Actions workflow for caching and Node.js

### DIFF
--- a/.github/workflows/test-doclet.yml
+++ b/.github/workflows/test-doclet.yml
@@ -20,17 +20,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: frank-doc
-
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-maven-dependencies
+          
+      - name: Restore cached directories
+        uses: actions/cache/restore@v4
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
+          path: |
+            ~/.m2/repository
+            ~/.sonar/cache
+          key: maven-build-cache
+      
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -42,10 +40,10 @@ jobs:
         with:
           version: 9
 
-      - name: Set up Node.js 21
+      - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 21
+          node-version: 22
           cache: 'pnpm'
           cache-dependency-path: frank-doc/frank-doc-frontend/pnpm-lock.yaml
 
@@ -100,3 +98,14 @@ jobs:
         with:
           name: FrankDoc.xsd
           path: frankframework/target/frankdoc/xml/xsd/*.xsd
+
+      - name: Save cached directories
+        uses: actions/cache/save@v4
+        if: |
+          always() &&
+          (github.ref == 'refs/heads/master')
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.sonar/cache
+          key: maven-build-cache


### PR DESCRIPTION
Updated caching strategy for Maven and Sonar directories in GitHub Actions workflow. Changed Node.js version from 21 to 22 and added restore/save cache steps.