### PR TITLE
Fix Maven to allow building with JDK25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
 		<revision>4.3.0-SNAPSHOT</revision>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.release>21</maven.compiler.release>
+    <maven.compiler.proc>full</maven.compiler.proc>
 	</properties>
 
 	<prerequisites>
@@ -90,7 +91,7 @@
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>flatten-maven-plugin</artifactId>
 			</plugin>
-			<plugin>
+      <plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 			</plugin>
@@ -181,10 +182,6 @@
 						<skipDeploy>true</skipDeploy>
 					</configuration>
 				</plugin>
-        <plugin>
-          <groupId>org.projectlombok</groupId>
-          <artifactId>lombok-maven-plugin</artifactId>
-        </plugin>
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>flatten-maven-plugin</artifactId>


### PR DESCRIPTION
The tests still do not pass with JDK25 but at least the Maven compiler now picks up Lombok annotations again.

Fixing individual tests will require changing whitespace in tests that now fail. This makes tests incompatible between JDK25 and older versions.
