### PR TITLE
Align FrankDocGroup annotation with the framework 

### DIFF
--- a/.github/workflows/test-doclet.yml
+++ b/.github/workflows/test-doclet.yml
@@ -44,8 +44,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: 'pnpm'
-          cache-dependency-path: frank-doc/frank-doc-frontend/pnpm-lock.yaml
 
       - name: Build with Maven
         env:

--- a/.github/workflows/test-doclet.yml
+++ b/.github/workflows/test-doclet.yml
@@ -41,9 +41,11 @@ jobs:
           version: 9
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
+          cache: 'pnpm'
+          cache-dependency-path: frank-doc/frank-doc-frontend/pnpm-lock.yaml          
 
       - name: Build with Maven
         env:

--- a/frank-doc-doclet/src/test/java/org/frankframework/doc/FrankDocGroup.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/doc/FrankDocGroup.java
@@ -20,7 +20,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 @Documented
-@Label(name = "FrankDocGroup")
+@Label(name = "Components")
 @Retention(RetentionPolicy.RUNTIME)
 public @interface FrankDocGroup {
 	FrankDocGroupValue value();

--- a/frank-doc-doclet/src/test/java/org/frankframework/doc/FrankDocGroupValue.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/doc/FrankDocGroupValue.java
@@ -16,26 +16,28 @@ limitations under the License.
 package org.frankframework.doc;
 
 public enum FrankDocGroupValue {
-	@EnumLabel("Pipe")
+	@EnumLabel("Pipes")
 	PIPE,
-	@EnumLabel("Sender")
+	@EnumLabel("Senders")
 	SENDER,
-	@EnumLabel("Listener")
+	@EnumLabel("Listeners")
 	LISTENER,
-	@EnumLabel("Validator")
+	@EnumLabel("Validators")
 	VALIDATOR,
-	@EnumLabel("Wrapper")
+	@EnumLabel("Wrappers")
 	WRAPPER,
-	@EnumLabel("TransactionalStorage")
+	@EnumLabel("TransactionalStorages")
 	TRANSACTIONAL_STORAGE,
-	@EnumLabel("ErrorMessageFormatter")
+	@EnumLabel("ErrorMessageFormatters")
 	ERROR_MESSAGE_FORMATTER,
 	@EnumLabel("Batch")
 	BATCH,
 	@EnumLabel("Monitoring")
 	MONITORING,
-	@EnumLabel("Job")
+	@EnumLabel("Scheduling")
 	JOB,
+	@EnumLabel("Parameters")
+	PARAMETER,
 	// This label is automatically added to the Module element.
 	@EnumLabel("Other")
 	OTHER,

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/integration/LabelTest.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/integration/LabelTest.java
@@ -2,10 +2,10 @@ package org.frankframework.frankdoc.integration;
 
 import org.junit.jupiter.api.Test;
 
-public class LabelTest extends BaseIntegrationTest {
+class LabelTest extends BaseIntegrationTest {
 
 	@Test
-	public void testJson() throws Exception {
+	void testJson() throws Exception {
 		var model = createModel(
 			GENERAL_DIGEST_RULES_FILE,
 			null,

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/integration/WrapperLabelTest.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/integration/WrapperLabelTest.java
@@ -1,0 +1,18 @@
+package org.frankframework.frankdoc.integration;
+
+import org.junit.jupiter.api.Test;
+
+class WrapperLabelTest extends BaseIntegrationTest {
+
+	@Test
+	void testWrapperPipeIsClassifiedAsWrapper() throws Exception {
+		var model = createModel(
+			"wrapper-label-test-digester-rules.xml",
+			null,
+			"org.frankframework.frankdoc.testtarget.examples.wrapper.Master"
+		);
+		var actual = convertModelToJson(model);
+
+		assertJsonEqual(actual, "wrapperLabels.json");
+	}
+}

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/examples/wrapper/IPipe.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/examples/wrapper/IPipe.java
@@ -1,0 +1,8 @@
+package org.frankframework.frankdoc.testtarget.examples.wrapper;
+
+import org.frankframework.doc.FrankDocGroup;
+import org.frankframework.doc.FrankDocGroupValue;
+
+@FrankDocGroup(FrankDocGroupValue.PIPE)
+public interface IPipe {
+}

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/examples/wrapper/IWrapperPipe.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/examples/wrapper/IWrapperPipe.java
@@ -1,0 +1,9 @@
+package org.frankframework.frankdoc.testtarget.examples.wrapper;
+
+import org.frankframework.doc.FrankDocGroup;
+import org.frankframework.doc.FrankDocGroupValue;
+
+// No @Components annotation: inherits "Pipes" from IPipe, just like the real IWrapperPipe
+@FrankDocGroup(FrankDocGroupValue.WRAPPER)
+public interface IWrapperPipe extends IPipe {
+}

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/examples/wrapper/Master.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/examples/wrapper/Master.java
@@ -1,0 +1,6 @@
+package org.frankframework.frankdoc.testtarget.examples.wrapper;
+
+public class Master {
+	public void addPipe(IPipe pipe) {
+	}
+}

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/examples/wrapper/MyRegularPipe.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/examples/wrapper/MyRegularPipe.java
@@ -1,0 +1,6 @@
+package org.frankframework.frankdoc.testtarget.examples.wrapper;
+
+// Element name will be "MyRegularPipe" (via addPipe(IPipe)).
+// Its label Components="Pipes" from IPipe should remain "Pipes"
+public class MyRegularPipe implements IPipe {
+}

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/examples/wrapper/MyWrapperPipe.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/examples/wrapper/MyWrapperPipe.java
@@ -1,0 +1,6 @@
+package org.frankframework.frankdoc.testtarget.examples.wrapper;
+
+// Element name will be "MyWrapperPipe" (via addPipe(IPipe), stripping "Pipe" + role "Pipe").
+// It inherited @FrankDocGroup = "Pipes" from IPipe, which should translate its components to "wrappers"
+public class MyWrapperPipe implements IWrapperPipe {
+}

--- a/frank-doc-doclet/src/test/resources/doc/examplesExpected/simple.json
+++ b/frank-doc-doclet/src/test/resources/doc/examplesExpected/simple.json
@@ -104,35 +104,35 @@
             ]
         }
     },
-    "elementNames": {
-        "DescribedPossibleIRoleNameIChild": {
-            "className": "org.frankframework.frankdoc.testtarget.examples.simple.DescribedPossibleIChild",
-            "labels": {
-                "FrankDocGroup": "Sender"
-            }
-        },
-        "Module": {
-            "className": "Module",
-            "labels": {
-                "FrankDocGroup": "Other"
-            }
-        },
-        "NotDescribedPossibleIRoleNameIChild": {
-            "className": "org.frankframework.frankdoc.testtarget.examples.simple.NotDescribedPossibleIChild",
-            "labels": {
-                "FrankDocGroup": "ErrorMessageFormatter"
-            }
-        },
-        "RoleNameTChild": {
-            "className": "org.frankframework.frankdoc.testtarget.examples.simple.TChild"
-        },
-        "Start": {
-            "className": "org.frankframework.frankdoc.testtarget.examples.simple.Start",
-            "labels": {
-                "FrankDocGroup": "Batch"
-            }
-        }
-    },
+	"elementNames" : {
+		"Module" : {
+			"className" : "Module",
+			"labels" : {
+				"FrankDocGroup" : "Other"
+			}
+		},
+		"NotDescribedPossibleIRoleNameIChild" : {
+			"className" : "org.frankframework.frankdoc.testtarget.examples.simple.NotDescribedPossibleIChild",
+			"labels" : {
+				"Components" : "ErrorMessageFormatters"
+			}
+		},
+		"Start" : {
+			"className" : "org.frankframework.frankdoc.testtarget.examples.simple.Start",
+			"labels" : {
+				"Components" : "Batch"
+			}
+		},
+		"DescribedPossibleIRoleNameIChild" : {
+			"className" : "org.frankframework.frankdoc.testtarget.examples.simple.DescribedPossibleIChild",
+			"labels" : {
+				"Components" : "Senders"
+			}
+		},
+		"RoleNameTChild" : {
+			"className" : "org.frankframework.frankdoc.testtarget.examples.simple.TChild"
+		}
+	},
     "skippableContainers": ["Root", "Module"],
     "enums": {
         "org.frankframework.frankdoc.testtarget.examples.simple.MyEnum": {
@@ -142,21 +142,9 @@
             }
         }
     },
-    "labels": {
-        "FrankDocGroup": [
-            "Pipe",
-            "Sender",
-            "Listener",
-            "Validator",
-            "Wrapper",
-            "TransactionalStorage",
-            "ErrorMessageFormatter",
-            "Batch",
-            "Monitoring",
-            "Job",
-            "Other"
-        ]
-    },
+	"labels" : {
+		"Components" : [ "Pipes", "Senders", "Listeners", "Validators", "Wrappers", "TransactionalStorages", "ErrorMessageFormatters", "Batch", "Monitoring", "Scheduling", "Parameters", "Other" ]
+	},
     "properties": [
         {
             "name": "First group",

--- a/frank-doc-doclet/src/test/resources/doc/examplesExpected/wrapperLabels.json
+++ b/frank-doc-doclet/src/test/resources/doc/examplesExpected/wrapperLabels.json
@@ -1,0 +1,126 @@
+{
+	"metadata": {
+		"version": "1.2.3-SNAPSHOT"
+	},
+	"types": {
+		"org.frankframework.frankdoc.testtarget.examples.wrapper.IPipe": [
+			"org.frankframework.frankdoc.testtarget.examples.wrapper.MyRegularPipe",
+			"org.frankframework.frankdoc.testtarget.examples.wrapper.MyWrapperPipe"
+		],
+		"org.frankframework.frankdoc.testtarget.examples.wrapper.Master": [
+			"org.frankframework.frankdoc.testtarget.examples.wrapper.Master"
+		],
+		"Module": [
+			"Module"
+		],
+		"PipelinePart": [
+			"PipelinePart"
+		]
+	},
+	"elements": {
+		"Module": {
+			"name": "Module",
+			"description": "Wrapper element to help split up large configuration files into smaller valid XML files. It may be used as root tag when an XML file contains multiple adapters and/or jobs. The Module element itself does not influence the behavior of Frank configurations."
+		},
+		"PipelinePart": {
+			"name": "PipelinePart",
+			"description": "Wrapper element to help create reusable parts of a pipeline"
+		},
+		"org.frankframework.frankdoc.testtarget.examples.wrapper.Master": {
+			"name": "Master",
+			"attributes": {
+				"active": {
+					"description": "If defined and empty or false, then this element and all its children are ignored"
+				}
+			},
+			"children": [
+				{
+					"multiple": true,
+					"roleName": "module",
+					"description": "Wrapper element to help split up large configuration files into smaller valid XML files. It may be used as root tag when an XML file contains multiple adapters and/or jobs. The Module element itself does not influence the behavior of Frank configurations.",
+					"type": "Module"
+				},
+				{
+					"multiple": true,
+					"roleName": "pipe",
+					"type": "org.frankframework.frankdoc.testtarget.examples.wrapper.IPipe"
+				}
+			]
+		},
+		"java.lang.Object": {
+			"name": "Object",
+			"attributes": {
+				"active": {
+					"description": "If defined and empty or false, then this element and all its children are ignored"
+				}
+			}
+		},
+		"org.frankframework.frankdoc.testtarget.examples.wrapper.MyWrapperPipe": {
+			"name": "MyWrapperPipe",
+			"attributes": {
+				"active": {
+					"description": "If defined and empty or false, then this element and all its children are ignored"
+				}
+			}
+		},
+		"org.frankframework.frankdoc.testtarget.examples.wrapper.MyRegularPipe": {
+			"name": "MyRegularPipe",
+			"attributes": {
+				"active": {
+					"description": "If defined and empty or false, then this element and all its children are ignored"
+				}
+			}
+		}
+	},
+	"elementNames": {
+		"Module": {
+			"className": "Module",
+			"labels": {
+				"FrankDocGroup": "Other"
+			}
+		},
+		"PipelinePart": {
+			"className": "PipelinePart",
+			"labels": {
+				"FrankDocGroup": "Other"
+			}
+		},
+		"Master": {
+			"className": "org.frankframework.frankdoc.testtarget.examples.wrapper.Master"
+		},
+		"MyWrapperPipe": {
+			"className": "org.frankframework.frankdoc.testtarget.examples.wrapper.MyWrapperPipe",
+			"labels": {
+				"Components": "Wrappers"
+			}
+		},
+		"MyRegularPipe": {
+			"className": "org.frankframework.frankdoc.testtarget.examples.wrapper.MyRegularPipe",
+			"labels": {
+				"Components": "Pipes"
+			}
+		}
+	},
+	"skippableContainers": [
+		"Module",
+		"Root"
+	],
+	"enums": {
+	},
+	"labels": {
+		"Components": [
+			"Pipes",
+			"Senders",
+			"Listeners",
+			"Validators",
+			"Wrappers",
+			"TransactionalStorages",
+			"ErrorMessageFormatters",
+			"Batch",
+			"Monitoring",
+			"Scheduling",
+			"Parameters",
+			"Other"
+		]
+	}
+}

--- a/frank-doc-doclet/src/test/resources/doc/wrapper-label-test-digester-rules.xml
+++ b/frank-doc-doclet/src/test/resources/doc/wrapper-label-test-digester-rules.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<digester-rules>
+  <rule pattern="*/pipe" registerMethod="addPipe"/>
+</digester-rules>


### PR DESCRIPTION
and add new test which proves correct labels are set

After some consideration, this should not be fixed in the doc, but in the framework.

Please also check https://github.com/frankframework/frankframework/pull/10987 for the change in the framework.

After these are merged, we need to check the generated json again.